### PR TITLE
Fix a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gem 'apparition'
 or
 
 ``` ruby
-gem apparition', github: 'twalpole/apparition'
+gem 'apparition', github: 'twalpole/apparition'
 ```
 
 to your Gemfile and run `bundle install`.


### PR DESCRIPTION
To fix a invalid Ruby syntax in README.