### PR TITLE
Allow #set to pass options to #set_text

### DIFF
--- a/lib/capybara/apparition/node.rb
+++ b/lib/capybara/apparition/node.rb
@@ -130,7 +130,7 @@ module Capybara::Apparition
         when 'datetime-local'
           set_datetime_local(value)
         else
-          set_text(value.to_s, delay: options.fetch(:delay, 0))
+          set_text(value.to_s, { delay: 0 }.merge(options))
         end
       elsif tag_name == 'textarea'
         set_text(value.to_s)


### PR DESCRIPTION
Allow #set to pass options for #set_text

In order to be able to pass some options, like an example below:

```ruby
find('input').set('sometext', clear: :backspace)
```