### PR TITLE
Fix `browser.set_proxy_aauth` typo?

### DIFF
--- a/lib/capybara/apparition/driver.rb
+++ b/lib/capybara/apparition/driver.rb
@@ -243,7 +243,7 @@ module Capybara::Apparition
     end
 
     def proxy_authorize(user = nil, password = nil)
-      browser.set_proxy_aauth(user, password)
+      browser.set_proxy_auth(user, password)
     end
 
     def basic_authorize(user = nil, password = nil)


### PR DESCRIPTION
Hello! I got real into the weeds of apparition today (isn't javascript just the best?) and noticed something that might be a typo... I couldn't find any methods that matched on `set_proxy_aauth`, however, there is a method [`set_proxy_auth`](https://github.com/twalpole/apparition/blob/master/lib/capybara/apparition/browser/auth.rb#L6) that seemed more ... fitting. 

Anyway, it didn't look like there was any test coverage. I'm happy to add some but I'm not sure what would be most impactful so I'm open to suggestions! If this wasn't a typo, then let's close this PR and pretend like it never happened. 