### PR TITLE
Add Node#property_names, Node#properties, similar to #attributes

### DIFF
--- a/lib/capybara/apparition/node.rb
+++ b/lib/capybara/apparition/node.rb
@@ -106,6 +106,14 @@ module Capybara::Apparition
       evaluate_on GET_ATTRIBUTES_JS
     end
 
+    def property_names
+      evaluate_on GET_PROPERTY_NAMES_JS
+    end
+
+    def properties
+      evaluate_on GET_PROPERTIES_JS
+    end
+
     def value
       evaluate_on GET_VALUE_JS
     end
@@ -704,6 +712,30 @@ module Capybara::Apparition
         for (let attr of this.attributes)
           attrs[attr.name] = attr.value.replace("\\n","\\\\n");
         return attrs;
+      }
+    JS
+
+    GET_PROPERTY_NAMES_JS = <<~JS
+      function(){
+        let props = [];
+        for (let prop in this) {
+          if (prop.match(/[a-z]/)) {
+            props.push(prop)
+          }
+        }
+        return props;
+      }
+    JS
+
+    GET_PROPERTIES_JS = <<~JS
+      function(){
+        let props = {};
+        for (let prop in this) {
+          if (prop.match(/[a-z]/)) {
+            props[prop] = this[prop]
+          }
+        }
+        return props;
       }
     JS
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,11 +16,12 @@ require 'support/capybara-webkit/output_writer'
 
 Capybara.register_driver :apparition do |app|
   debug = !ENV['DEBUG'].nil?
+  headless = ENV['HEADLESS'].nil?
   options = {
     logger: TestSessions.logger,
     inspector: debug,
     debug: debug,
-    headless: true
+    headless: headless
   }
 
   Capybara::Apparition::Driver.new(


### PR DESCRIPTION
Not sure if this would be helpful to others, but when I was trying to figure out a way to check validity (#20), I needed a way to see what properties apparition was actually seeing and found these methods useful...

The `prop.match(/[a-z]/` was to exclude all these properties:

```
=> {"0"=>{"type"=>"object", "subtype"=>"node", "className"=>"Option", "description"=>"option", "objectId"=>"{\"injectedScriptId\":2,\"id\":369}"},
 "1"=>{"type"=>"object", "subtype"=>"node", "className"=>"HTMLOptionElement", "description"=>"option", "objectId"=>"{\"injectedScriptId\":2,\"id\":370}"},
 "2"=>{"type"=>"object", "subtype"=>"node", "className"=>"HTMLOptionElement", "description"=>"option", "objectId"=>"{\"injectedScriptId\":2,\"id\":371}"},
 "3"=>{"type"=>"object", "subtype"=>"node", "className"=>"HTMLOptionElement", "description"=>"option", "objectId"=>"{\"injectedScriptId\":2,\"id\":372}"},
```
(I'm sure there's a better way to do that, but what is it?)