### PR TITLE
Fixes bug: TypeError: exception class/object expected

### DIFF
--- a/lib/capybara/apparition/node.rb
+++ b/lib/capybara/apparition/node.rb
@@ -759,7 +759,7 @@ module Capybara::Apparition
     # if an area element, check visibility of relevant image
     VISIBLE_JS = <<~JS
       function(){
-        el = this;
+        let el = this;
         if (el.tagName == 'AREA'){
           const map_name = document.evaluate('./ancestor::map/@name', el, null, XPathResult.STRING_TYPE, null).stringValue;
           el = document.querySelector(`img[usemap='#${map_name}']`);


### PR DESCRIPTION
Recently, I've received an error on all interactions with capybara (e.g. fill_in(foo), click_on(bla)),

I've only received the output: "TypeError: exception class/object expected"

After digging into the process_response, I've got this error from the server:

```
{"result"=>
  {"type"=>"object",
   "subtype"=>"error",
   "className"=>"TypeError",
   "description"=>"TypeError: Assignment to constant variable.\n    at HTMLInputElement.<anonymous> (<anonymous>:4:6)\n    at HTMLInputElement.<anonymous> (<anonymous>:29:4)",
   "objectId"=>"{\"injectedScriptId\":2,\"id\":8}"},
 "exceptionDetails"=>
  {"exceptionId"=>1,
   "text"=>"Uncaught",
   "lineNumber"=>3,
   "columnNumber"=>5,
   "scriptId"=>"23",
   "stackTrace"=>{"callFrames"=>[{"functionName"=>"", "scriptId"=>"23", "url"=>"", "lineNumber"=>3, "columnNumber"=>5}, {"functionName"=>"", "scriptId"=>"23", "url"=>"", "lineNumber"=>28, "columnNumber"=>3}]},
   "exception"=>
    {"type"=>"object",
     "subtype"=>"error",
     "className"=>"TypeError",
     "description"=>"TypeError: Assignment to constant variable.\n    at HTMLInputElement.<anonymous> (<anonymous>:4:6)\n    at HTMLInputElement.<anonymous> (<anonymous>:29:4)",
     "objectId"=>"{\"injectedScriptId\":2,\"id\":9}"}}}
```

Saw the raw "el = this" without let/const modifier and added let. That seemed to fix the problem.

Chrome Version:
- Google Chrome 76.0.3809.132
- Apparition: 0.4.0
- Capybara:  3.29.0