### PR TITLE
Add integration test to show send_keys emoji bug

### DIFF
--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -1415,6 +1415,14 @@ module Capybara::Apparition
         expect(input.value).to eq('apparition')
       end
 
+      it 'sends emojis' do
+        input = @session.find(:css, '#empty_input')
+
+        input.native.send_keys('😀')
+
+        expect(input.value).to eq('😀')
+      end
+
       it 'has an alias' do
         input = @session.find(:css, '#empty_input')
 


### PR DESCRIPTION
This only adds the test. I'm all thumbs with ruby and couldn't get the test to run on my machine, but I'm fairly certain it will fail in CI. 🤞