### PR TITLE
Fix full-page screenshots in some circumstances.

### DIFF
--- a/lib/capybara/apparition/page.rb
+++ b/lib/capybara/apparition/page.rb
@@ -157,7 +157,7 @@ module Capybara::Apparition
           %w[x y width height].each_with_object({}) { |key, hash| hash[key] = pos[key] }
         elsif options[:full]
           evaluate <<~JS
-            { width: document.documentElement.clientWidth, height: document.documentElement.clientHeight}
+            { width: document.documentElement.scrollWidth, height: document.documentElement.scrollHeight}
           JS
         else
           evaluate <<~JS

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -145,13 +145,16 @@ module Capybara::Apparition
         @session.visit('/apparition/long_page')
 
         create_screenshot file
-        expect(FastImage.size(file)).to eq(
+        screenshot_size = FastImage.size(file)
+        expect(screenshot_size).to eq(
           @driver.evaluate_script('[window.innerWidth, window.innerHeight]')
         )
 
         create_screenshot file, full: true
-        expect(FastImage.size(file)).to eq(
-          @driver.evaluate_script('[document.documentElement.clientWidth, document.documentElement.clientHeight]')
+        full_screenshot_size = FastImage.size(file)
+        expect(full_screenshot_size).not_to eq(screenshot_size)
+        expect(full_screenshot_size).to eq(
+          @driver.evaluate_script('[document.documentElement.scrollWidth, document.documentElement.scrollHeight]')
         )
       end
 
@@ -185,7 +188,7 @@ module Capybara::Apparition
         create_screenshot file, full: true, selector: '#penultimate'
 
         expect(FastImage.size(file)).to eq(
-          @driver.evaluate_script('[document.documentElement.clientWidth, document.documentElement.clientHeight]')
+          @driver.evaluate_script('[document.documentElement.scrollWidth, document.documentElement.scrollHeight]')
         )
       end
 

--- a/spec/support/views/long_page.erb
+++ b/spec/support/views/long_page.erb
@@ -1,3 +1,9 @@
+<style>
+  html {
+    height: 100%;
+  }
+</style>
+
 <div style="min-width: 300">
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin lacus odio, dapibus id bibendum in, rhoncus sed dolor. In quis nulla at diam euismod suscipit vitae vitae sapien. Nam viverra hendrerit augue a accumsan. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Fusce fermentum tortor at neque malesuada sodales. Nunc quis augue a quam venenatis pharetra sit amet et risus. Nulla pharetra enim a leo varius scelerisque aliquam urna vestibulum. Sed felis eros, iaculis convallis fermentum ac, condimentum ac lacus. Sed turpis magna, tristique eu faucibus non, faucibus vitae elit. Morbi venenatis adipiscing aliquam.</p>
 


### PR DESCRIPTION
Even adding just <!DOCTYPE html> to long_page.erb will kick Chrome into a different rendering mode but setting html's height to 100% seems to be the more reliable method.

Fixes #39.