### PR TITLE
Add support for Ruby loggers in addition to "puts"-quacking objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Upcoming
+
+### Added
+* Support Ruby loggers in the :logger and :browser_logger option [Daniel Orner]
+
 # Version 0.5.0
 Release date: 2020-01-26
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ end
 
 *   `:headless` (Boolean) - When false, run the browser visibly
 *   `:debug` (Boolean) - When true, debug output is logged to `STDERR`.
-*   `:logger` (Object responding to `puts`) - When present, debug output is written to this object
+*   `:logger` (Ruby logger object or any object responding to `puts`) - When present, debug output is written to this object
 *   `:browser_logger` (`IO` object) - This is where your `console.log` statements will show up. Default: `STDOUT`
 *   `:timeout` (Numeric) - The number of seconds we'll wait for a response
     when communicating with Chrome. Default is 30.

--- a/lib/capybara/apparition/browser.rb
+++ b/lib/capybara/apparition/browser.rb
@@ -187,7 +187,12 @@ module Capybara::Apparition
   private
 
     def log(message)
-      @logger&.puts message if ENV['DEBUG']
+      return if !@logger || !ENV['DEBUG']
+      if @logger.respond_to?(:puts)
+        @logger.puts(message)
+      else
+        @logger.debug(message)
+      end
     end
 
     def initialize_handlers

--- a/lib/capybara/apparition/console.rb
+++ b/lib/capybara/apparition/console.rb
@@ -9,7 +9,13 @@ module Capybara::Apparition
 
     def log(type, message, **options)
       @messages << OpenStruct.new(type: type, message: message, **options)
-      @logger&.puts "#{type}: #{message}"
+      return unless @logger
+      message_to_log = "#{type}: #{message}"
+      if @logger.respond_to?(:puts)
+        @logger.puts(message_to_log)
+      else
+        @logger.info(message_to_log)
+      end
     end
 
     def clear

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'pdf/reader'
 require 'chunky_png'
 require 'fastimage'
+require 'logger'
 require 'os'
 
 module Capybara::Apparition
@@ -37,6 +38,27 @@ module Capybara::Apparition
       it 'supports capturing console.log' do
         session.visit('/apparition/console_log')
         expect(logger.string).to include('Hello world')
+      end
+    end
+
+    context 'output redirection with Ruby logger' do
+      let(:io) { StringIO.new }
+      let(:logger) { Logger.new(io) }
+      let(:session) { Capybara::Session.new(:apparition_with_logger, TestApp) }
+
+      before do
+        Capybara.register_driver :apparition_with_logger do |app|
+          Capybara::Apparition::Driver.new(app, browser_logger: logger)
+        end
+      end
+
+      after do
+        session.driver.quit
+      end
+
+      it 'supports capturing console.log' do
+        session.visit('/apparition/console_log')
+        expect(io.string).to include('Hello world')
       end
     end
 


### PR DESCRIPTION
See #57.

Let me know if I missed anything or made any mistakes @twalpole.

Thanks!