### PR TITLE
Support new browser versions for remote launcher

### DIFF
--- a/lib/capybara/apparition/browser/launcher/remote.rb
+++ b/lib/capybara/apparition/browser/launcher/remote.rb
@@ -43,11 +43,20 @@ module Capybara::Apparition
       protected
 
         def get_ws_url(host, port)
-          response = Net::HTTP.get(host, '/json/version', port)
-          response = JSON.parse(response)
-          response['webSocketDebuggerUrl']
+          version = fetch_version(host, port)
+          ws_url = version['webSocketDebuggerUrl']
+          ws_url.insert(ws_url.index('/devtools'), "#{host}:#{port}")
         rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
           raise ArgumentError, "Cannot connect to remote Chrome at: 'http://#{host}:#{port}/json/version'"
+        end
+
+        def fetch_version(host, port)
+          uri = URI.parse("http://#{host}:#{port}/json/version")
+          http = Net::HTTP.new(uri.host, uri.port)
+          request = Net::HTTP::Get.new(uri.request_uri)
+          request.add_field('Host', '')
+          response = http.request(request)
+          JSON.parse(response.body)
         end
       end
     end


### PR DESCRIPTION
Since 66.0.3359.26 Chrome version, you need to specify the Host header as an IP address or localhost. 
This issue was mentioned here:
[https://bugs.chromium.org/p/chromium/issues/detail?id=813540](url)
[https://github.com/OnetapInc/chromy/issues/110](url)
[https://github.com/cyrus-and/chrome-remote-interface/issues/340](url)

You can override the default Host header and set it to the empty string. You will receive webSocketDebuggerUrl like that
`"webSocketDebuggerUrl": "ws:///devtools/page/A4566872556EA7F94C344A8ABEA30A73"`
And than just insert right host and port.
Without this fix, you will receive the error "Host header is specified and is not an IP address or localhost" for any chrome version > 65