### PR TITLE
make Page.frameNavigated accept additional keywords

### DIFF
--- a/lib/capybara/apparition/page.rb
+++ b/lib/capybara/apparition/page.rb
@@ -463,8 +463,8 @@ module Capybara::Apparition
         puts "**** frameDetached called with #{frame_id} : #{params}" if ENV['DEBUG']
       end
 
-      @session.on 'Page.frameNavigated' do |frame:|
-        puts "**** frameNavigated called with #{frame}" if ENV['DEBUG']
+      @session.on 'Page.frameNavigated' do |frame:, **params|
+        puts "**** frameNavigated called with #{frame} : #{params}" if ENV['DEBUG']
         unless @frames.exists?(frame['id'])
           puts "**** creating frame for #{frame['id']}" if ENV['DEBUG']
           @frames.add(frame['id'], frame)


### PR DESCRIPTION
Running apparition with Chrome on WSL2, which updated this morning, started throwing this error on every frame navigation:
`Unexpected inner loop exception: unknown keyword: :type: unknown keyword: :type: ["/home/david/apparition/lib/capybara/apparition/page.rb:466:in `block in register_eve
nt_handlers'", "/home/david/apparition/lib/capybara/apparition/driver/chrome_client.rb:209:in `block in process_handlers'", "/home/david/apparition/lib/capybara/appari
tion/driver/chrome_client.rb:207:in `each'", "/home/david/apparition/lib/capybara/apparition/driver/chrome_client.rb:207:in `process_handlers'", "/home/david/apparitio
n/lib/capybara/apparition/driver/chrome_client.rb:185:in `block in process_messages'", "/home/david/apparition/lib/capybara/apparition/driver/chrome_client.rb:175:in `
loop'", "/home/david/apparition/lib/capybara/apparition/driver/chrome_client.rb:175:in `process_messages'", "/home/david/apparition/lib/capybara/apparition/driver/chro
me_client.rb:215:in `block in start_threads'"]`

The examples still ran fine. So I changed the session handler to accept all keywords and log them for debug, following the example of other event handlers in that method.