### PR TITLE
Fix resource leaks

### DIFF
--- a/lib/capybara/apparition/driver/chrome_client.rb
+++ b/lib/capybara/apparition/driver/chrome_client.rb
@@ -51,6 +51,7 @@ module Capybara::Apparition
 
     def stop
       @ws.close
+      @events.push(nil)
     end
 
     def on(event_name, session_id = nil, &block)
@@ -159,6 +160,7 @@ module Capybara::Apparition
 
     def cleanup_async_responses
       loop do
+        break if [:closing, :closed].include?(@ws.driver.state)
         @msg_mutex.synchronize do
           @message_available.wait(@msg_mutex, 0.1)
           (@responses.keys & @async_ids).each do |msg_id|
@@ -173,6 +175,7 @@ module Capybara::Apparition
     def process_messages
       # run handlers in own thread so as not to hang message processing
       loop do
+        break if [:closing, :closed].include?(@ws.driver.state)
         event = @events.pop
         next unless event
 


### PR DESCRIPTION
After quitting a local Chrome session, two threads (one running `cleanup_async_responses`, and one running `process_messages`) continue executing forever. This uses up memory and CPU time. If many sessions are started and quit, all available memory will eventually be consumed.

To demonstrate the problem, run this code and keep the Ruby interpreter running:
```ruby
10.times do
  session = Capybara.current_session
  session.visit("about:blank")
  session.quit
end
```
Observe (for instance, using `top -H`) that 20 threads remain.

To fix the problem, I've added exit conditions to the two problematic loops. I'm not sure whether checking the status of `@ws` is the best approach, but it works in my testing.