### PR TITLE
Initialize ChromeClient timeout with default Capybara timeout

### DIFF
--- a/lib/capybara/apparition/driver.rb
+++ b/lib/capybara/apparition/driver.rb
@@ -66,7 +66,7 @@ module Capybara::Apparition
       @client ||= begin
         @launcher ||= Browser::Launcher.start(options)
         ws_url = @launcher.ws_url
-        ::Capybara::Apparition::ChromeClient.client(ws_url.to_s)
+        ::Capybara::Apparition::ChromeClient.client(ws_url.to_s).tap { |client| client.timeout = session_wait_time }
       end
     end
 


### PR DESCRIPTION
When using `session.visit()`, if the page includes indefinitely running Javascript, apparition hangs and never timeouts.

To reproduce the issue, create an HTML page having the following code and `session.visit` it:
```html
<script>
	while(true) { }
</script>
```
Observe apparition hanging indefinitely.  

To fix the problem, I'm initializing the `ChromeClient` with the `session_wait_time` value.