### PR TITLE
Raise a more specific error if the websocket connection dies

### DIFF
--- a/lib/capybara/apparition/driver/chrome_client.rb
+++ b/lib/capybara/apparition/driver/chrome_client.rb
@@ -194,6 +194,8 @@ module Capybara::Apparition
         puts "Unexpected CDPError: #{e.message}"
       end
       retry
+    rescue WebSocketClientError => e
+      puts "Unexpected websocket connection exception: #{e}: #{e.message}: #{e.backtrace}"
     rescue StandardError => e
       puts "Unexpected inner loop exception: #{e}: #{e.message}: #{e.backtrace}"
       retry

--- a/lib/capybara/apparition/driver/web_socket_client.rb
+++ b/lib/capybara/apparition/driver/web_socket_client.rb
@@ -4,6 +4,8 @@ require 'websocket/driver'
 
 module Capybara::Apparition
   class WebSocketClient
+    class WebSocketClientError < StandardError; end;
+
     attr_reader :driver, :messages, :status
 
     def initialize(url)
@@ -55,19 +57,26 @@ module Capybara::Apparition
     end
 
     def parse_input
-      @driver.parse(@socket.read)
+      data = @socket.read
+      raise WebSocketClientError.new("Received empty data message from websocket, indicating a timeout or dead connection.") if data.nil? || data.empty?
+      @driver.parse(data)
+    rescue EOFError, Errno::ECONNRESET => e
+      raise WebSocketClientError.new("Received a low-level error when reading from websocket: #{e.inspect}")
     end
   end
 
   require 'socket'
 
   class Socket
+    CONNECT_TIMEOUT = ENV.fetch("APPARITION_SOCKET_CONNECT_TIMEOUT", 5).to_i
+    READ_TIMEOUT = ENV.fetch("APPARITION_SOCKET_READ_TIMEOUT", 5).to_i
+
     attr_reader :url
 
     def initialize(url)
       @url = url
       uri = URI.parse(url)
-      @io = TCPSocket.new(uri.host, uri.port)
+      @io = ::Socket.tcp(uri.host, uri.port, connect_timeout: CONNECT_TIMEOUT)
     end
 
     def write(data)
@@ -75,7 +84,15 @@ module Capybara::Apparition
     end
 
     def read
-      @io.readpartial(1024)
+      retries = 0
+      begin
+        @io.read_nonblock(1024)
+      rescue IO::WaitReadable
+        retries += 1
+        IO.select([@io], nil, nil, READ_TIMEOUT)
+        retry if retries <= 1
+        nil
+      end
     end
   end
 end


### PR DESCRIPTION
We're having an issue in our CI environment where our container is sporadically timing out, and we _think_ it may be because the Chrome client is dying silently or disconnecting, and Apparition is not realizing it.

I'm able to reproduce the issue of Apparition hanging locally by starting some specs in one terminal window, and `kill`ing  the Chrome process that is spawned via another terminal window using `killall -m Chrome` (careful if you are actually using Chrome at the time). Killing Chrome causes apparition to hang permanently - the only way to get the specs to stop is Ctrl+C (twice).

After looking into why that happens, I thought this issue might hold the answer https://github.com/faye/websocket-driver-ruby/issues/61 . Apparently, it's possible that the Websocket Driver's connection fails without firing the `:close` event. In addition to listening for that event, we should also check the return value of `#read` and ensure it's not `nil` or an empty string.

Well, I tried just checking for `nil` and `""`, and it didn't seem to work. I was able to verify that the `socket.read` call was where apparition was hanging, and it seems the `readpartial` call is blocking, so I replaced it with `read_nonblock`. That method is, according to the docs, the exact same other than the blocking flag. Once I used the non-blocking form of `read`, and raised an error when the timeout occurs, I see the expected error output, but apparition continues to hang 😞 . This happens _even if I set the `abort_on_exception` flag to true on the `@listener` thread. 😕  I have no idea why.

I'm hoping you can help me build on this PR to properly address this issue.