### PR TITLE
use scrollWidth and scrollHeight for full page screenshot saves.

### DIFF
--- a/lib/capybara/apparition/page.rb
+++ b/lib/capybara/apparition/page.rb
@@ -157,7 +157,7 @@ module Capybara::Apparition
           %w[x y width height].each_with_object({}) { |key, hash| hash[key] = pos[key] }
         elsif options[:full]
           evaluate <<~JS
-            { width: document.documentElement.clientWidth, height: document.documentElement.clientHeight}
+            { width: document.documentElement.scrollWidth, height: document.documentElement.scrollHeight}
           JS
         else
           evaluate <<~JS

--- a/lib/capybara/apparition/page.rb
+++ b/lib/capybara/apparition/page.rb
@@ -165,6 +165,7 @@ module Capybara::Apparition
           JS
         end
         options[:clip] = { x: 0, y: 0, scale: scale }.merge(clip_options)
+        options[:captureBeyondViewport] = true
         command('Page.captureScreenshot', **options)
       end['data']
     end

--- a/spec/integration/driver_spec.rb
+++ b/spec/integration/driver_spec.rb
@@ -169,7 +169,7 @@ module Capybara::Apparition
 
         create_screenshot file, full: true
         expect(FastImage.size(file)).to eq(
-          @driver.evaluate_script('[document.documentElement.clientWidth, document.documentElement.clientHeight]')
+          @driver.evaluate_script('[document.documentElement.scrollWidth, document.documentElement.scrollHeight]')
         )
       end
 
@@ -203,7 +203,7 @@ module Capybara::Apparition
         create_screenshot file, full: true, selector: '#penultimate'
 
         expect(FastImage.size(file)).to eq(
-          @driver.evaluate_script('[document.documentElement.clientWidth, document.documentElement.clientHeight]')
+          @driver.evaluate_script('[document.documentElement.scrollWidth, document.documentElement.scrollHeight]')
         )
       end
 


### PR DESCRIPTION
I noticed that the bottom of my screenshots were getting cut off...it wasn't expanding quite far enough.  When I switched to `cuprite`, however, it would work and capture the entire viewport properly.  I studied the difference and `cuprite` is using `scrollWidth` and `scrollHeight` at https://github.com/rubycdp/ferrum/blob/3253bf1d028945b434ffb8e3d42636342ebf15bc/lib/ferrum/page/screenshot.rb#L66