### PR TITLE
Allow to change user data dir

### DIFF
--- a/lib/capybara/apparition/browser/launcher/local.rb
+++ b/lib/capybara/apparition/browser/launcher/local.rb
@@ -40,7 +40,7 @@ module Capybara::Apparition
             @options.merge!(HEADLESS_OPTIONS)
             @options['disable-gpu'] = nil if Capybara::Apparition.windows?
           end
-          @options['user-data-dir'] = Dir.mktmpdir
+          @options['user-data-dir'] ||= Dir.mktmpdir
         end
 
         def start


### PR DESCRIPTION
Fix apparition overriding the `user-data-dir` even if it was specified in `browser_options`